### PR TITLE
Add preseed for mint 18.3 XFCE

### DIFF
--- a/mint_18_3.seed
+++ b/mint_18_3.seed
@@ -1,0 +1,50 @@
+### Localization
+# Setting this bypasses the 'Select a name for this batch of systems page in the OEM installer'
+d-i debian-installer/locale string en_US 
+
+# Keyboard selection
+d-i keyboard-configuration/layoutcode string us
+
+# You may set this to any valid setting for $TZ; see the contents of
+# /usr/share/zoneinfo/ for valid values.
+d-i time/zone string US/Central
+
+### Partitioning
+d-i partman-md/device_remove_md boolean true
+# This prevents the 'are you sure you want to write these partitions' prompt
+d-i partman/confirm_nooverwrite boolean true 
+
+# Continue regular partitioning
+d-i partman-auto/method string regular
+d-i partman-auto/init_automatically_partition select biggest_free
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home: separate /home partition
+# - multi: separate /home, /usr, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+d-i partman/default_filesystem string ext4
+
+# This makes partman automatically partition without confirmation, provided
+# that you told it what to do using one of the methods above.
+d-i partman/choose_partition select finish
+# d-i partman/confirm boolean true
+
+### Account setup
+d-i passwd/user-fullname string oem
+d-i passwd/username string oem
+# Important: You MUST populate the user-fullname and username fields to skip the password prompt
+d-i passwd/user-password password password
+d-i passwd/user-password-again password password
+d-i netcfg/get_hostname string freegeekchicago
+
+### Finishing up the installation
+# Avoid that last message about the install being complete.
+ubiquity ubiquity/summary note
+# This will hide the 'restart now' dialog
+# This is commented out because it's often helpful to have that dialog so we know the installation finished
+# ubiquity ubiquity/reboot boolean true
+
+# We can use this to run a command once the install finishes
+# Maybe we should run the install.sh script here?
+ubiquity ubiquity/success_command


### PR DESCRIPTION
I've spend several hours testing this and it seems to fully automate the installation of Mint 18.3! Hopefully we can get this on the PXEBoot server soon so we don't have to keep manually clicking through the install process.